### PR TITLE
165051: Allow Udp Inbound VNET to VNET

### DIFF
--- a/infra/network/subnet-nsg.parameters.json
+++ b/infra/network/subnet-nsg.parameters.json
@@ -33,6 +33,23 @@
                 }
             },
             {
+                "name": "AllowAnyUdpInboundVnet",
+                "properties": {
+                    "protocol": "Udp",
+                    "sourcePortRange": "*",
+                    "destinationPortRange": "*",
+                    "sourceAddressPrefix": "VirtualNetwork",
+                    "destinationAddressPrefix": "VirtualNetwork",
+                    "access": "Allow",
+                    "priority": 2010,
+                    "direction": "Inbound",
+                    "sourcePortRanges": [],
+                    "destinationPortRanges": [],
+                    "sourceAddressPrefixes": [],
+                    "destinationAddressPrefixes": []
+                }
+            },
+            {
                 "name": "AllowAnyInboundFromAzLB",
                 "properties": {
                     "protocol": "*",


### PR DESCRIPTION
# Description
Allow all UDP ports inbound traffic within the Virtual network

[AB#165051](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/165051)