### PR TITLE
234076: Use default environments

### DIFF
--- a/.azuredevops/deploy-platform-core.yaml
+++ b/.azuredevops/deploy-platform-core.yaml
@@ -35,14 +35,6 @@ extends:
   parameters:
     projectName: $(projectName)
     deployFromFeature: ${{ parameters.deployFromFeature }}
-    environments:
-      - name: 'snd1'
-        serviceConnection: AZD-ADP-SND1
-        deploymentBranches:
-          - 'refs/heads/main'
-        developmentEnvironment: true
-        azureRegions:
-          primary: 'UKSouth'
     groupedTemplates:
       - name: network
         templates:


### PR DESCRIPTION
# Description
Removed environments from the pipeline to use the defaults defined in the common pipeline. 

[AB#234076](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/234076)